### PR TITLE
[Feat] 개인 정보 수정 페이지 접근을 위한 비밀번호 재확인 페이지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "lit": "^3.2.1",
         "pocketbase": "^0.23.0",
-        "sweetalert2": "^11.15.2"
+        "sweetalert2": "^11.6.13"
       },
       "devDependencies": {
         "eslint": "^8.56.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   "dependencies": {
     "lit": "^3.2.1",
     "pocketbase": "^0.23.0",
-    "sweetalert2": "^11.15.2"
+    "sweetalert2": "^11.6.13"
   }
 }

--- a/src/pages/pwConfirm/index.html
+++ b/src/pages/pwConfirm/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="ko-KR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/styles/base.css" />
+    <script type="module" src="/src/pages/pwConfirm/index.js"></script>
+    <script src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@9"></script>
+
+    <title>%MODE%</title>
+  </head>
+  <body>
+    <c-header></c-header>
+    <pw-confirm></pw-confirm>
+    <c-footer></c-footer>
+  </body>
+</html>

--- a/src/pages/pwConfirm/index.js
+++ b/src/pages/pwConfirm/index.js
@@ -1,0 +1,3 @@
+import '/src/Layout/Header/index.js';
+import '/src/Layout/Footer/index.js';
+import '/src/pages/pwConfirm/pwConfirm.js';

--- a/src/pages/pwConfirm/pwConfirm.css
+++ b/src/pages/pwConfirm/pwConfirm.css
@@ -1,0 +1,95 @@
+.pw-confirm {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  margin-bottom: 3.125rem;
+}
+
+.pw-confirm__fieldset {
+  width: 600px;
+}
+
+.pw-confirm__legend {
+  font-family: 'Pretendard Variable', Pretendard, sans-serif;
+  font-size: var(--text-2xl);
+  font-weight: var(--font-semibold);
+  line-height: var(--line-height-loose);
+  padding-top: 2.75rem;
+}
+
+.pw-confirm__title {
+  font-family: 'Pretendard Variable', Pretendard, sans-serif;
+  font-size: var(--text-2xl);
+  font-weight: var(--font-semibold);
+  line-height: var(--line-height-loose);
+}
+
+.pw-confirm__description {
+  font-family: 'Pretendard Variable', Pretendard, sans-serif;
+  font-size: var(--text-sm);
+  color: var(--gray--700);
+  padding-bottom: 1.25rem;
+}
+
+.pw-confirm__form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.25rem;
+  border-top: 3px solid var(--black);
+  padding-block: 30px;
+  border-bottom: 1px solid var(--gray--200);
+}
+
+.pw-confirm__form-group {
+  display: flex;
+  flex-direction: row;
+}
+
+.pw-confirm__label-wrapper {
+  width: 8.75rem;
+  padding-top: 1.125rem;
+}
+
+.pw-confirm__label {
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  line-height: var(--line-height-normal);
+}
+
+.pw-confirm--required {
+  color: var(--info---error);
+}
+
+.pw-confirm__input {
+  font-family: 'Pretendard Variable', Pretendard, sans-serif;
+  font-size: var(--text-base);
+  font-weight: var(--font-regular);
+  line-height: var(--line-height-semirelaxed);
+  color: var(--gray--400);
+  width: 18.75rem;
+  height: 3.125rem;
+  border-radius: 0.25rem;
+  border: 0.0625rem solid var(--gray--200);
+  padding-inline: 1.25rem;
+}
+.pw-confirm__button {
+  background-color: var(--primary);
+  color: var(--white);
+  width: 21.25rem;
+  height: 3.375rem;
+  border: none;
+  border-radius: 0.25rem;
+  font-family: 'Pretendard Variable', Pretendard, sans-serif;
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  line-height: var(--line-height-normal);
+  display: block;
+  margin: 2.5rem auto;
+}
+
+.pw-confirm__button:disabled {
+  background-color: var(--gray--400);
+  color: var(--black);
+  cursor: not-allowed;
+}

--- a/src/pages/pwConfirm/pwConfirm.js
+++ b/src/pages/pwConfirm/pwConfirm.js
@@ -1,0 +1,117 @@
+import { LitElement, html } from 'lit';
+import style from '/src/pages/pwConfirm/pwConfirm.css?inline';
+import resetCSS from '/src/styles/reset.css?inline';
+import pb from '/src/api/pocketbase.js';
+import Swal from 'sweetalert2';
+
+class PwConfirm extends LitElement {
+  static properties = {
+    isPwValid: { type: Boolean },
+    userId: { type: String },
+  };
+
+  constructor() {
+    super();
+    this.isPwValid = false;
+    this.userId = '';
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.getUserId();
+  }
+
+  getUserId() {
+    const loginData = JSON.parse(localStorage.getItem('auth') ?? '{}');
+
+    const { user } = loginData;
+    this.userId = user ? user.userId : '';
+  }
+
+  async fetchData() {
+    const pwInput = this.shadowRoot.querySelector('#user-pw');
+    const userPw = pwInput.value;
+    const idInput = this.shadowRoot.querySelector('#user-id');
+    const userId = idInput.value;
+
+    console.log(userId);
+
+    try {
+      await pb
+        .collection('users')
+        .authWithPassword(userId, userPw)
+        .then(() => {
+          location.href = '/src/pages/mypage/';
+        });
+    } catch {
+      Swal.fire('비밀번호를 확인해주세요.');
+    }
+  }
+
+  handlePwConfirm(e) {
+    e.preventDefault();
+    this.fetchData();
+  }
+
+  render() {
+    return html`
+      <style>
+        ${resetCSS}
+        ${style}
+      </style>
+      <form action="/" class="pw-confirm" method="">
+        <fieldset class="pw-confirm__fieldset">
+          <legend class="pw-confirm__legend">개인 정보 수정</legend>
+          <p class="pw-confirm__title">비밀번호 재확인</p>
+          <p class="pw-confirm__description">
+            회원님의 정보를 안전하게 보호하기 위해 비밀번호를 다시 한번
+            확인해주세요.
+          </p>
+          <div class="pw-confirm__form">
+            <div class="pw-confirm__form-group">
+              <div class="pw-confirm__label-wrapper">
+                <label for="user-id" class="pw-confirm__label">아이디</label>
+              </div>
+              <input
+                type="text"
+                class="pw-confirm__input"
+                id="user-id"
+                name="user-id"
+                value=${this.userId}
+              />
+            </div>
+            <div class="pw-confirm__form-group">
+              <div class="pw-confirm__label-wrapper">
+                <label
+                  for="user-pw"
+                  class="pw-confirm__label pw-confirm__label--required"
+                  >비밀번호</label
+                ><span class="pw-confirm--required" aria-label="필수 입력 요소"
+                  >*</span
+                >
+              </div>
+              <input
+                type="password"
+                class="pw-confirm__input"
+                name="user-pw"
+                id="user-pw"
+                placeholder="현재 비밀번호를 입력해주세요"
+                required
+                aria-required="true"
+              />
+            </div>
+          </div>
+          <button
+            type="submit"
+            class="pw-confirm__button pw-confirm__button--submit"
+            @click=${this.handlePwConfirm}
+          >
+            확인
+          </button>
+        </fieldset>
+      </form>
+    `;
+  }
+}
+
+customElements.define('pw-confirm', PwConfirm);


### PR DESCRIPTION
- 비밀번호 재확인 페이지 마크업&스타일링
- 아이디 입력란은 로컬스토리지에서 가져오기
- 비밀번호 재확인 완료 후 개인 정보 수정 페이지로 이동

resolves #98

## PR 유형
- [x] 새로운 기능 추가

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 이슈
resolves #98