### PR TITLE
[Modify] 개인정보 수정 페이지 렌더링 정보 업데이트

### DIFF
--- a/src/pages/mypage/mypage.js
+++ b/src/pages/mypage/mypage.js
@@ -158,6 +158,21 @@ class MyPage extends LitElement {
     return formGroupData;
   }
 
+  handleUpdateLocalStorage() {
+    const { record, token } = JSON.parse(
+      localStorage.getItem('pocketbase_auth') ?? '{}'
+    );
+
+    localStorage.setItem(
+      'auth',
+      JSON.stringify({
+        isAuth: !!record,
+        user: record,
+        token: token,
+      })
+    );
+  }
+
   handleUpdate(e) {
     e.preventDefault();
     const formData = this.extractFormData();
@@ -190,6 +205,8 @@ class MyPage extends LitElement {
         pb.collection('users')
           .update(recordId, data)
           .then(() => {
+            this.handleUpdateLocalStorage();
+
             Swal.fire({
               title: '정보가 수정되었습니다.',
               icon: 'success',
@@ -210,6 +227,8 @@ class MyPage extends LitElement {
             birth: formData.birth,
           })
           .then(() => {
+            this.handleUpdateLocalStorage();
+
             Swal.fire({
               title: '정보가 수정되었습니다.',
               icon: 'success',


### PR DESCRIPTION
- 수정하기 버튼 클릭 후 db 데이터 업데이트 시 로컬 스토리지 정보도 업데이트 하여 페이지 재방문 시 업데이트된 정보가 렌더링될 수 있도록 수정

resolves #178

## PR 유형
- [x] 버그 수정

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 이슈
resolves #178